### PR TITLE
Fix for weird ease-in effect when moving cropping box

### DIFF
--- a/dist/public/Stash Performer Image Cropper.user.js
+++ b/dist/public/Stash Performer Image Cropper.user.js
@@ -30,6 +30,9 @@
 
     const css = GM_getResourceText("IMPORTED_CSS");
     GM_addStyle(css);
+    
+    // The generated image iamge from cropperjs had problems with a transition property set somewhere else on stash. This CSS style cancels that effect.
+    GM_addStyle(`.cropper-view-box img { -webkit-transition: none !important; -moz-transition: none !important; -o-transition: none !important; transition: none !important; }`);
 
     let cropping = false;
     let cropper = null;

--- a/src/body/Stash Performer Image Cropper.user.js
+++ b/src/body/Stash Performer Image Cropper.user.js
@@ -16,6 +16,9 @@
     const css = GM_getResourceText("IMPORTED_CSS");
     GM_addStyle(css);
 
+    // The generated image iamge from cropperjs had problems with a transition property set somewhere else on stash. This CSS style cancels that effect.
+    GM_addStyle(`.cropper-view-box img { -webkit-transition: none !important; -moz-transition: none !important; -o-transition: none !important; transition: none !important; }`);
+
     let cropping = false;
     let cropper = null;
 


### PR DESCRIPTION
Hope you don't mind, I took a long look at what was going wrong, and figured out it was a conflict between the new Stash UI CSS and CropperJs's CSS. I manually injected some CSS to counter that effect. 